### PR TITLE
fix(request): erros eram ignorados

### DIFF
--- a/mundipagg.go
+++ b/mundipagg.go
@@ -9,7 +9,7 @@ type Mundipagg interface {
 	NewSubscription(subscription *Subscription, uuid string) (*Response, error)
 	NewCustomer(customer *Customer, uuid string) (*Response, error)
 	NewCardByToken(customerID string, cardToken string, uuid string) (*Response, error)
-	UpdateStartAt(input *string, customerID string, uuid string) (*Response, error)
+	UpdateStartAt(input *string, subscriptionID string, uuid string) (*Response, error)
 	UpdateNextBillingDay(nextBillingDay *time.Time, customerID string, uuid string) (*Response, error)
 	AddDiscount(billExtras *BillExtras, subscriptionID string, uuid string) (*Response, error)
 }
@@ -66,13 +66,13 @@ func (m mundipagg) NewSubscription(s *Subscription, uuid string) (*Response, err
 	return resp, nil
 }
 
-func (m mundipagg) UpdateStartAt(startAt *string, customerID string, uuid string) (*Response, error) {
+func (m mundipagg) UpdateStartAt(startAt *string, subscriptionID string, uuid string) (*Response, error) {
 	input := struct {
 		StartAt *string `json:"start_at,omitempty"`
 	}{
 		StartAt: startAt,
 	}
-	completeURL := SUBSCRIPTIONURL + "/" + customerID + SUBSCRIPTIONUPDATESTARTATURL
+	completeURL := SUBSCRIPTIONURL + "/" + subscriptionID + SUBSCRIPTIONUPDATESTARTATURL
 	resp, err := Do(http.MethodPatch, input, m.BasicSecretAuthKey, uuid, completeURL)
 	if err != nil {
 		return nil, err

--- a/request.go
+++ b/request.go
@@ -34,7 +34,7 @@ type Response struct {
 func Do(method string, data interface{}, secretKey string, indepotencyKey string, url string) (*Response, error) {
 	postData, err := json.Marshal(data)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(postData))
@@ -62,7 +62,7 @@ func Do(method string, data interface{}, secretKey string, indepotencyKey string
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		err = errors.New("Invalid Request:\nSent:\n" + string(postData) + "Received:\n" + string(body))
+		return nil, errors.New("Invalid Request:\nSent:\n" + string(postData) + "Received:\n" + string(body))
 	}
 
 	response := &Response{MundipaggJSONAnswer: string(body)}


### PR DESCRIPTION
quando uma request tinha status code de erro, o erro nao era retornado e era sobescrito depois e acabava sendo perdido
